### PR TITLE
feat(components): add border classes to list-groups

### DIFF
--- a/components/collapsible-item/styles.less
+++ b/components/collapsible-item/styles.less
@@ -32,7 +32,8 @@
 .list-group-item {
   &.collapsible-item {
     padding: 0;
-    border: none;
+    border-top: none;
+    border-bottom: none;
 
     &:hover {
       background-color: transparent;
@@ -50,8 +51,8 @@
     [data-toggle=collapse] {
       padding: @list-item-padding;
       padding-right: @list-item-padding-right + (@indicator-size * 2);
-      border: 1px solid @gray-lighter;
       border-top: none;
+      border-bottom: none;
       position: relative;
 
       &:hover {
@@ -134,7 +135,8 @@
     }
 
     &.active {
-      border-color: @brand-primary;
+      border-top-color: @brand-primary;
+      border-bottom-color: @brand-primary;
       background-color: @brand-primary;
       [data-toggle=collapse] {
         border-bottom: none;

--- a/components/dropdown-item/styles.less
+++ b/components/dropdown-item/styles.less
@@ -1,7 +1,7 @@
 .dropdown-item {
 
   &:hover {
-    background-color: transparent;
+    background-color: #fff;
     cursor: default;
   }
 

--- a/components/list-groups/basic.html
+++ b/components/list-groups/basic.html
@@ -1,10 +1,13 @@
 <p>The most basic list group is simply an unordered list with list items, and the proper classes. Apply the <code>.active</code> class to highlight a list item. Apply the <code>.unselectable</code> class to remove the item hover style.</p>
-<p>Apply the <code>.list-group-item-muted</code> class to provide a distinct style useful for header rows. Apply the <code>.list-group-item-condensed</code> class to reduce the top/bottom padding on the item, which is useful for providing a distinct row style when using with header rows.</p>
+<p>Apply the <code>.list-group-item-muted</code> class to provide a distinct style useful for header rows.</p>
+<p>Apply the <code>.list-group-item-condensed</code> class to reduce the top/bottom padding on the item, which is useful for providing a distinct row style when using with header rows.</p>
+<p>Apply the <code>.list-group-item-borderless</code> class to remove the top border on a list-group-item, which is useful for stronger association of list items.</p>
 <example>
   <ul class="list-group">
     <li class="list-group-item">Dapibus ac facilisis in</li>
     <li class="list-group-item active">Active item. Cras justo odio</li>
     <li class="list-group-item">Dapibus ac facilisis in</li>
+    <li class="list-group-item list-group-item-borderless">Remove item border. Dapibus ac facilisis in</li>
     <li class="list-group-item unselectable">Without hover state. Dapibus ac facilisis in</li>
     <li class="list-group-item list-group-item-muted unselectable">Muted state. Dapibus ac facilisis in</li>
     <li class="list-group-item list-group-item-condensed">Condensed list item. Dapibus ac facilisis in</li>

--- a/components/list-groups/borders.html
+++ b/components/list-groups/borders.html
@@ -1,0 +1,41 @@
+<p>All list groups are minimally styled with no outer borders and only a thin top level border per item. This ensures the aesthetics of the list when placed within an app. However, there are occasions when a list group requires a top or bottom border to visually break up the components on the page.</p>
+<p>Applying the <code>.list-group-border-top</code> class will set a border on the top of the list group.</p>
+<p>Applying the <code>.list-group-border-bottom</code> class will set a border on the bottom of the list group.</p>
+<p>Applying the <code>.list-group-border-vertical</code> class will set a border on the sides  of the list group.</p>
+<p>If you require to apply a complete border on top, bottom and sides, then rather than adding the three classes above, you can apply the <code>.list-group-border-all</code> class which has the same effect as applying the three above classes to the list-group element.</p>
+
+<div class="row">
+  <div class="col-md-4">
+    <title>Border Top</title>
+    <example>
+      <ul class="list-group list-group-border-top">
+        <li class="list-group-item">Dapibus ac facilisis in</li>
+        <li class="list-group-item">Duis velit libero</li>
+        <li class="list-group-item">Mauris laoreet a libero</li>
+        <li class="list-group-item">Vivamus eget egestas</li>
+      </ul>
+    </example>
+  </div>
+  <div class="col-md-4">
+    <title>Border Bottom</title>
+    <example>
+      <ul class="list-group list-group-border-bottom">
+        <li class="list-group-item">Dapibus ac facilisis in</li>
+        <li class="list-group-item">Duis velit libero</li>
+        <li class="list-group-item">Mauris laoreet a libero</li>
+        <li class="list-group-item">Vivamus eget egestas</li>
+      </ul>
+    </example>
+  </div>
+  <div class="col-md-4">
+    <title>Border Vertical</title>
+    <example>
+      <ul class="list-group list-group-border-vertical">
+        <li class="list-group-item">Dapibus ac facilisis in</li>
+        <li class="list-group-item">Duis velit libero</li>
+        <li class="list-group-item">Mauris laoreet a libero</li>
+        <li class="list-group-item">Vivamus eget egestas</li>
+      </ul>
+    </example>
+  </div>
+</div>

--- a/components/media-group-item/styles.less
+++ b/components/media-group-item/styles.less
@@ -1,7 +1,6 @@
 @media-group-item-padding: 16px;
 
 .media-group-item {
-  border: none;
   text-decoration: none;
 }
 
@@ -9,15 +8,6 @@
   &.media-group-item {
     cursor: pointer;
     padding: @media-group-item-padding;
-    border-bottom: 1px solid @gray-lighter;
-
-    &:last-child {
-      border-bottom: none;
-    }
-
-    &:only-child {
-      border-top: none;
-    }
 
     &:hover {
       background-color: @gray-lightest;
@@ -33,7 +23,7 @@
 
     &.active {
       background-color: @component-active-bg;
-      border-bottom: 1px solid @component-active-bg;
+      border-color: @component-active-bg;
 
       *:not(.media-badge) {
         > * {
@@ -48,4 +38,3 @@
     }
   }
 }
-

--- a/docs/build.json
+++ b/docs/build.json
@@ -72,7 +72,8 @@
     "list-groups": [
       "basic",
       "badge",
-      "content"
+      "content",
+      "borders"
     ],
     "inline-form-item": [
       "individual",

--- a/overrides/bootstrap/components/list-groups.less
+++ b/overrides/bootstrap/components/list-groups.less
@@ -1,25 +1,61 @@
 // List groups  ==============================================================
 
-.list-group-item {
-  padding: 8px 15px;
-  margin-bottom: 0px;
-}
-
 .list-group-item-condensed {
   padding: 6px 15px;
 }
 
-.list-group-item {
+.list-group-border-top {
   border-top: 1px solid @gray-lighter;
+}
+
+.list-group-border-bottom {
+  border-bottom: 1px solid @gray-lighter;
+}
+
+.list-group-border-vertical .list-group-item {
+  border-left: 1px solid @gray-lighter;
+  border-right: 1px solid @gray-lighter;
+}
+
+.list-group-border-all {
+  border-top: 1px solid @gray-lighter;
+  border-bottom: 1px solid @gray-lighter;
+
+  .list-group-item {
+    border-left: 1px solid @gray-lighter;
+    border-right: 1px solid @gray-lighter;
+  }
+}
+
+ul.list-group > li > ul li {
+  border-left: none !important;
+  border-right: none !important;
+}
+
+.list-group-item {
+  border: none;
+  padding: 8px 15px;
+  margin-bottom: 0px;
 
   &:hover {
     cursor: pointer;
     background-color: @gray-lightest;
   }
+
+  &.list-group-item-borderless {
+    border-top: none !important;
+  }
+
+  &.active {
+    &:hover, &:focus {
+      border-left-color: @gray-lighter;
+      border-right-color: @gray-lighter;
+    }
+  }
 }
 
 .list-group-item:not([style*="display: none"]):not(first-child) ~ .list-group-item {
-  border-top: none;
+  border-top: 1px solid @gray-lighter;
 }
 
 .list-group-item.unselectable {
@@ -50,4 +86,3 @@ a.list-group-item-muted {
     color: @gray-dark;
   }
 }
-


### PR DESCRIPTION
By default, the list groups will no longer have a side border or an
absolute top or bottom border. This ensures that all list group types
look aesthetically correct within apps.

However, sometimes it is required to have a list border top or bottom,
and in certain cases it may be required to have a left/right border as
well. To accommodate this requirement, the following classes have been
added that need to be applied alongside the `.list-group` class:

  * `.list-group-border-top` -> applies a top border to the list
  * `.list-group-border-bottom` -> applies a bottom border to the list
  * `.list-group-border-vertical` -> applies a side border to the list
  * `.list-group-border-all` -> applies all the above styles