### PR TITLE
chore(list-group): remove hard font-color dependency from muted style

### DIFF
--- a/components/list-groups/basic.html
+++ b/components/list-groups/basic.html
@@ -9,7 +9,7 @@
     <li class="list-group-item">Dapibus ac facilisis in</li>
     <li class="list-group-item list-group-item-borderless">Remove item border. Dapibus ac facilisis in</li>
     <li class="list-group-item unselectable">Without hover state. Dapibus ac facilisis in</li>
-    <li class="list-group-item list-group-item-muted unselectable">Muted state. Dapibus ac facilisis in</li>
+    <li class="list-group-item list-group-item-muted unselectable text-muted-dark">Muted state. Dapibus ac facilisis in</li>
     <li class="list-group-item list-group-item-condensed">Condensed list item. Dapibus ac facilisis in</li>
   </ul>
 </example>

--- a/docs/examples/filter-lists/basic-inline.html
+++ b/docs/examples/filter-lists/basic-inline.html
@@ -74,11 +74,11 @@
           <br/>
         </div>
         <ul class="list-group">
-          <li class="list-group-item list-group-item-muted unselectable"><strong>Finance</strong></li>
+          <li class="list-group-item list-group-item-muted unselectable text-muted-dark"><strong>Finance</strong></li>
           <li class="list-group-item list-group-item-condensed">Arthur</li>
           <li class="list-group-item list-group-item-condensed">David</li>
           <li class="list-group-item list-group-item-condensed">Brian</li>
-          <li class="list-group-item list-group-item-muted unselectable"><strong>Human Resources</strong></li>
+          <li class="list-group-item list-group-item-muted unselectable text-muted-dark"><strong>Human Resources</strong></li>
           <li class="list-group-item list-group-item-condensed">Simon</li>
           <li class="list-group-item list-group-item-condensed">Luther</li>
           <li class="list-group-item list-group-item-condensed">Nathan</li>
@@ -171,7 +171,7 @@
 
             if (currentIndex !== currentHeader) {
               var header = document.createElement("li");
-              header.setAttribute("class", "list-group-item list-group-item-muted unselectable");
+              header.setAttribute("class", "list-group-item list-group-item-muted unselectable text-muted-dark");
               header.innerHTML = "<strong>" + currentIndex+ "</strong>";
 
               list.appendChild(header);

--- a/overrides/bootstrap/components/list-groups.less
+++ b/overrides/bootstrap/components/list-groups.less
@@ -77,12 +77,10 @@ ul.list-group > li > ul li {
 .list-group-item-muted,
 a.list-group-item-muted {
   background-color: @gray-lightest;
-  color: @gray-dark;
 }
 
 .list-group-item-muted.unselectable {
   &:hover, &:focus {
     background-color: @gray-lightest;
-    color: @gray-dark;
   }
 }


### PR DESCRIPTION
The `list-group-item-muted` no longer has a hard coded font colour and
just changes the background of the list-group-item to a muted colour.

This enables more flexibility in the component as different colours can
be applied if required. If the previous font colour is required then a
`text-muted-dark` class can be applied to the list-group-item to provide
the same style.

The examples have been updated to show the new changes.