### PR TITLE
refactor(collapsible-item): reduce size of indicator icon

### DIFF
--- a/components/collapsible-item/styles.less
+++ b/components/collapsible-item/styles.less
@@ -1,6 +1,6 @@
 @list-item-padding: 8px 15px;
 @list-item-padding-right: 12px;
-@indicator-size: 7px;
+@indicator-size: 6px;
 
 .nested-padding(@base-padding: 15px, @increment: 15px) {
   &.padding-1-left, .padding-1-left {


### PR DESCRIPTION
The size of the collapsible item indicator icon has been reduced.