### PR TITLE
fix(list-group): apply active font color to all list groups

### DIFF
--- a/components/collapsible-item/styles.less
+++ b/components/collapsible-item/styles.less
@@ -117,47 +117,6 @@
       border-bottom-color: @brand-primary;
       background-color: @brand-primary;
 
-      > *:not(.list-group) {
-        color: #fff;
-
-        .text-muted-dark {
-          color: #fff;
-        }
-
-        .text-muted-light {
-          color: #fff;
-        }
-
-        .text-muted {
-          color: #fff;
-        }
-
-        .text-primary,
-        .text-primary:hover {
-          color: #fff;
-        }
-
-        .text-success,
-        .text-success:hover {
-          color: #fff;
-        }
-
-        .text-danger,
-        .text-danger:hover {
-          color: #fff;
-        }
-
-        .text-warning,
-        .text-warning:hover {
-          color: #fff;
-        }
-
-        .text-info,
-        .text-info:hover {
-          color: #fff;
-        }
-      }
-
       > [data-toggle=collapse] {
         border-bottom: none;
         border-color: @brand-primary;

--- a/overrides/bootstrap/components/list-groups.less
+++ b/overrides/bootstrap/components/list-groups.less
@@ -56,6 +56,47 @@ ul.list-group > li > ul li {
   }
 
   &.active {
+    > *:not(.list-group) {
+      color: #fff;
+
+      .text-muted-dark {
+        color: #fff;
+      }
+
+      .text-muted-light {
+        color: #fff;
+      }
+
+      .text-muted {
+        color: #fff;
+      }
+
+      .text-primary,
+      .text-primary:hover {
+        color: #fff;
+      }
+
+      .text-success,
+      .text-success:hover {
+        color: #fff;
+      }
+
+      .text-danger,
+      .text-danger:hover {
+        color: #fff;
+      }
+
+      .text-warning,
+      .text-warning:hover {
+        color: #fff;
+      }
+
+      .text-info,
+      .text-info:hover {
+        color: #fff;
+      }
+    }
+
     &:hover, &:focus {
       border-left-color: @gray-lighter;
       border-right-color: @gray-lighter;


### PR DESCRIPTION
Previously, the active font color was only being applied to collapsible
lists. It is now applied to all lists as this fixes an issue with
active list items not having the correct font color.