### PR TITLE
feat(grid-row): support text-center

### DIFF
--- a/components/grid-row/styles.less
+++ b/components/grid-row/styles.less
@@ -1,5 +1,23 @@
 @cell-margin: 5px;
 
+.text-right {
+  &:not(.text-left):not(.text-center) {
+    text-align: right;
+  }
+}
+
+.text-left {
+  &:not(.text-center):not(.text-right) {
+    text-align: left;
+  }
+}
+
+.text-center {
+  &:not(.text-left):not(.text-right) {
+    text-align: center;
+  }
+}
+
 .grid-row {
   .display-flex;
   .align-items(center);
@@ -10,6 +28,8 @@
 
   & > * {
     .flex-grow(1);
+    .text-right;
+
     width: 1%;
     margin-right: @cell-margin;
 
@@ -17,14 +37,20 @@
       margin-right: 0;
     }
 
-    &:not(.text-left) {
-      text-align: right;
-    }
-
     &:first-child {
-      &:not(.text-right) {
-        text-align: left;
-      }
+      .text-left;
     }
+  }
+
+  &.text-center * {
+    .text-center;
+  }
+
+  &.text-left * {
+    .text-left;
+  }
+
+  &.text-right * {
+    .text-right;
   }
 }

--- a/docs/examples/collapsible-lists/grid-list.html
+++ b/docs/examples/collapsible-lists/grid-list.html
@@ -68,4 +68,74 @@
       </ul>
     </example>
   </div>
+
+  <div class="col-md-6">
+    <example>
+      <ul class="list-group list-group-border-bottom list-group-with-indicators collapsible">
+        <li class="list-group-item grid-row text-center unselectable">
+          <h6 class="text-left"><strong>Item</strong></h6>
+          <h6><strong>Actual (£)</strong></h6>
+          <h6><strong>Target (£)</strong></h6>
+          <h6><strong>val (%)</strong></h6>
+        </li>
+        <li class="list-group-item list-group-item-muted text-center grid-row unselectable">
+          <h5 class="text-left">Revenue</h5>
+          <h5>1342</h5>
+          <h5>0</h5>
+          <h5>88</h5>
+        </li>
+        <li class="list-group-item list-group-item-muted collapsible-item">
+          <div class="grid-row collapsed text-center" data-toggle="collapse" data-target="#grid-2-nested-1">
+            <h5 class="text-left">Revenue</h5>
+            <h5>2630</h5>
+            <h5>11</h5>
+            <h5>244</h5>
+          </div>
+          <ul id="grid-2-nested-1" class="list-group text-muted-dark">
+            <li class="list-group-item grid-row text-center unselectable">
+              <h6 class="text-left">ILF</h6>
+              <h6>120</h6>
+              <h6>3</h6>
+              <h6>54</h6>
+            </li>
+
+            <li class="list-group-item grid-row text-center unselectable">
+              <h6 class="text-left">CLF</h6>
+              <h6>1222</h6>
+              <h6>0</h6>
+              <h6>100</h6>
+            </li>
+
+            <li class="list-group-item collapsible-item unselectable">
+              <div class="grid-row collapsed text-muted-dark text-center" data-toggle="collapse" data-target="#grid-2-nested-2">
+                <h6 class="text-left">ALF</h6>
+                <h6>1288</h6>
+                <h6>8</h6>
+                <h6>90</h6>
+              </div>
+              <ul id="grid-2-nested-2" class="list-group">
+                <li class="list-group-item list-group-item-borderless grid-row text-center text-muted-dark unselectable">
+                  <div>
+                    <h5 class="padding-1-left text-left small">Annual License & Support</h5>
+                  </div>
+                  <h5 class="small">804</h5>
+                  <h5 class="small">4</h5>
+                  <h5 class="small">90</h5>
+                </li>
+
+                <li class="list-group-item list-group-item-borderless grid-row text-center text-muted-dark unselectable line-looser">
+                  <div>
+                    <h5 class="padding-1-left text-left small">Annual Fee</h5>
+                  </div>
+                  <h5 class="small">804</h5>
+                  <h5 class="small">4</h5>
+                  <h5 class="small">90</h5>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </example>
+  </div>
 </div>


### PR DESCRIPTION
The `grid-row` component now supports `text-center` overrides on
individual elements within a row.

Additionally `text-right`, `text-left` and `text-center` can be applied
to a `grid-row` and these styles will override the default text
alignment rules for elements within a row.

An example has been provided that demonstrates a grid list that
demonstrates centering data in columns.