### PR TITLE
feat(panel): enforce `panel-title` to be capitalized

### DIFF
--- a/overrides/bootstrap/components/panels.less
+++ b/overrides/bootstrap/components/panels.less
@@ -31,6 +31,7 @@
   margin-top: 0;
   margin-bottom: 0;
   color: inherit;
+  text-transform: capitalize;
 
   > a {
     color: inherit;


### PR DESCRIPTION
The bootstrap overrides for the `panel` component have been updated to
enforce `panel-title` content to be capitalized by default.