### PR TITLE
fix(collapsible-item): reset non active item text color

### DIFF
--- a/components/collapsible-item/styles.less
+++ b/components/collapsible-item/styles.less
@@ -33,8 +33,11 @@
     border-top: none;
     border-bottom: none;
 
-    &:not(.active) {
-      color: initial;
+    &.active {
+      .list-group-item:not(.active) {
+        .text-status-colors;
+        color: @text-color;
+      }
     }
 
     &:not(.list-group-item-muted):not(.active) {

--- a/components/mixins.less
+++ b/components/mixins.less
@@ -69,3 +69,43 @@
   -ms-flex-positive: @grow;
   flex-grow: @grow;
 }
+
+.text-status-colors {
+  &.text-muted-dark {
+    color: @gray-dark;
+  }
+
+  &.text-muted-light {
+    color: @gray-light;
+  }
+
+  &.text-normal,
+  &.text-normal:hover {
+    color: @text-color;
+  }
+
+  &.text-primary,
+  &.text-primary:hover {
+    color: @brand-primary;
+  }
+
+  &.text-success,
+  &.text-success:hover {
+    color: @brand-success;
+  }
+
+  &.text-danger,
+  &.text-danger:hover {
+    color: @brand-danger;
+  }
+
+  &.text-warning,
+  &.text-warning:hover {
+    color: @brand-warning;
+  }
+
+  &.text-info,
+  &.text-info:hover {
+    color: @brand-info;
+  }
+}

--- a/overrides/bootstrap/components/typography.less
+++ b/overrides/bootstrap/components/typography.less
@@ -8,50 +8,14 @@ strong {
   font-weight: 500;
 }
 
+.text-status-colors;
+
 .text-weaker {
   font-weight: 300;
 }
 
 .text-stronger {
   font-weight: 700;
-}
-
-.text-muted-dark {
-  color: @gray-dark;
-}
-
-.text-muted-light {
-  color: @gray-light;
-}
-
-.text-normal,
-.text-normal:hover {
-  color: @text-color;
-}
-
-.text-primary,
-.text-primary:hover {
-  color: @brand-primary;
-}
-
-.text-success,
-.text-success:hover {
-  color: @brand-success;
-}
-
-.text-danger,
-.text-danger:hover {
-  color: @brand-danger;
-}
-
-.text-warning,
-.text-warning:hover {
-  color: @brand-warning;
-}
-
-.text-info,
-.text-info:hover {
-  color: @brand-info;
 }
 
 h1, h2, h3, h4 {


### PR DESCRIPTION
Commit 7ec5860f set the color of non-active `collapsible-item` elements
to be `initial`, which had the effect of setting the `color` property
to its default value, which in the case of most browsers is black
(#000000).

From a Bootstrap perspective this behaviour was not desirable due to the
fact that the `body` element is styled to explicitly set the `color`
to `@text-color` less variable (which is not black).

The ideal solution would be to set the color of non-active items to be
`inherit` to make sure the element takes its cues from the nearest
parent. However this is problematic if the nearest parent has an
`active` class applied. As in these situations we don't want the active
text color to cascade.

Therefore in response to the fact that neither `initial` or `inherit`
are suitable candidates this commit takes the following approach:

 * Nested `list-group-item` elements that are not `active` have their
   color set to the default theme text color, unless the item in
   question has a text status color explicitly applied to it.

To accomplish this task the text-status classes have extracted into a
reusable less mixin.