### PR TITLE
feat(badge): add outline badge style

### DIFF
--- a/components/badge/styles.less
+++ b/components/badge/styles.less
@@ -1,5 +1,7 @@
-.badge-style-variant(@background-color) {
-  background-color: @background-color;
+.badge-inverse-style-variant(@color) {
+  border: 1px solid @color;
+  background-color: #fff;
+  color: @color;
 }
 
 .badge-default {
@@ -24,4 +26,29 @@
 
 .badge-danger {
   background-color: @brand-danger;
+}
+
+.badge-default-inverse {
+  .badge-inverse-style-variant(@gray);
+  border-color: @gray-lighter;
+}
+
+.badge-primary-inverse {
+  .badge-inverse-style-variant(@brand-primary);
+}
+
+.badge-success-inverse {
+  .badge-inverse-style-variant(@brand-success);
+}
+
+.badge-info-inverse {
+  .badge-inverse-style-variant(@brand-info);
+}
+
+.badge-warning-inverse {
+  .badge-inverse-style-variant(@brand-warning);
+}
+
+.badge-danger-inverse {
+  .badge-inverse-style-variant(@brand-danger);
 }

--- a/components/indicators/badges.html
+++ b/components/indicators/badges.html
@@ -1,4 +1,5 @@
 <p>Easily highlight new or unread items by adding a <code>&lt;span class="badge"&gt;</code> to links, navs, and more.</p>
+<title>Filled</title>
 <example>
   <ul class="nav nav-pills">
     <li class="active"><a href="#">Home <span class="badge">1</span></a></li>
@@ -8,5 +9,17 @@
     <li><a href="#">Info <span class="badge badge-info">1</span></a></li>
     <li><a href="#">Warning <span class="badge badge-warning">1</span></a></li>
     <li><a href="#">Danger <span class="badge badge-danger">1</span></a></li>
+  </ul>
+</example>
+<title>Outlined</title>
+<example>
+  <ul class="nav nav-pills">
+    <li class="active"><a href="#">Home <span class="badge">1</span></a></li>
+    <li><a href="#">Default <span class="badge badge-default-inverse">1</span></a></li>
+    <li><a href="#">Primary <span class="badge badge-primary-inverse">1</span></a></li>
+    <li><a href="#">Success <span class="badge badge-success-inverse">1</span></a></li>
+    <li><a href="#">Info <span class="badge badge-info-inverse">1</span></a></li>
+    <li><a href="#">Warning <span class="badge badge-warning-inverse">1</span></a></li>
+    <li><a href="#">Danger <span class="badge badge-danger-inverse">1</span></a></li>
   </ul>
 </example>


### PR DESCRIPTION
A badge can also be displayed in an outline version (the same as buttons
and labels). Providing the suffix of `-inverse` to a badge class will
create an outline version:

  * `badge-default-inverse`
  * `badge-primary-inverse`
  * `badge-success-inverse`
  * `badge-info-inverse`
  * `badge-warning-inverse`
  * `badge-danger-inverse`